### PR TITLE
Remove annoying println()

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -161,7 +161,6 @@ function mvnormcdf(μ::AbstractVector, Σ::AbstractMatrix, a::AbstractVector, b:
     bt = copy_oftype(b, T)
     at .-= μ
     bt .-= μ
-    println(at, " ", bt)
     ##################################################################
     #
     # Special cases: positive Orthant probabilities for 2- and


### PR DESCRIPTION
Hey ! 

I was wondering why Copulas.jl did start to output stuff during precompilation... It looks like in version 0.3.1 you forgot to remove a `println()` statement in the middle of your code. 

Would you agree to remove it and re-tag a release ? :) It's nothing, but it's producing warnings on precompilation that were a bit scary on my side

Thanks again for the great work on this package!